### PR TITLE
remove.py need import os 

### DIFF
--- a/pisi/api.py
+++ b/pisi/api.py
@@ -962,7 +962,7 @@ def clearCache(all=False):
 
         # sort dictionary by value from PEP-265
         from operator import itemgetter
-        return sorted(iter(sizes.items()), key=itemgetter(1), reverse=False)
+        return sorted(iter(list(sizes.items())), key=itemgetter(1), reverse=False)
 
     def removeOrderByLimit(cacheDir, order, limit):
         totalSize = 0

--- a/pisi/operations/remove.py
+++ b/pisi/operations/remove.py
@@ -12,6 +12,7 @@
 
 import gettext
 import sys
+import os
 
 import pisi
 import pisi.atomicoperations as atomicoperations


### PR DESCRIPTION
```
pisi hs -t 234
Following packages will be removed:
libXau libXau-devel libbsd libXdmcp libXdmcp-devel libxcb libxcb-devel libX11 libX11-devel autoconf-archive xorg-proto expat-32bit libcap-ng-devel expat-devel 
Do you want to continue? (yes/no)y
The following list of packages will be removed
in the respective order to satisfy dependencies:
expat-devel libXau libcap-ng-devel expat-32bit autoconf-archive libbsd libXau-devel libxcb-devel libXdmcp-devel libX11-devel libX11 xorg-proto libxcb libXdmcp 
Removing package expat-devel
Running pre removal operations for expat-devel
Running post removal operations for expat-devel
Removed expat-devel
Removing package libXau
Running pre removal operations for libXau
Running post removal operations for libXau
Removed libXau
System error. Program terminated.
name 'os' is not defined
Please use 'pisi help' for general help.
Use --debug to see a traceback.
5052c89cd4bf pisi_1 # pisi hs -t 234 --debug
DEBUG: HistoryDB initialized in 0.0013244152069091797.
DEBUG: InstallDB initialized in 0.4263601303100586.
Following packages will be removed:
libXau-devel libbsd libXdmcp libXdmcp-devel libxcb libxcb-devel libX11 libX11-devel autoconf-archive xorg-proto expat-32bit libcap-ng-devel 
Do you want to continue? (yes/no)y
The following list of packages will be removed
in the respective order to satisfy dependencies:
libXdmcp-devel libXdmcp libcap-ng-devel xorg-proto expat-32bit libX11-devel libX11 libXau-devel libbsd libxcb-devel libxcb autoconf-archive 
Removing package libXdmcp-devel
Running pre removal operations for libXdmcp-devel
DEBUG: Calling pre remove handlers
DEBUG: FilesDB initialized in 0.0026421546936035156.
Running post removal operations for libXdmcp-devel
DEBUG: Calling post remove handlers
DEBUG: Unregistering comar scripts
Removed libXdmcp-devel
System error. Program terminated.
<class 'NameError'>: name 'os' is not defined
Please use 'pisi help' for general help.

Traceback:
  File "/usr/bin/pisi", line 85, in <module>
    cli.run_command()
  File "/usr/lib/python3.6/site-packages/pisi/cli/pisicli.py", line 146, in run_command
    self.command.run()
  File "/usr/lib/python3.6/site-packages/pisi/cli/history.py", line 123, in run
    self.takeback(opno)
  File "/usr/lib/python3.6/site-packages/pisi/cli/history.py", line 61, in takeback
    pisi.api.takeback(operation)
  File "/usr/lib/python3.6/site-packages/pisi/api.py", line 69, in wrapper
    ret = func(*__args,**__kw)
  File "/usr/lib/python3.6/site-packages/pisi/api.py", line 491, in takeback
    pisi.operations.history.takeback(operation)
  File "/usr/lib/python3.6/site-packages/pisi/operations/history.py", line 166, in takeback
    pisi.operations.remove.remove(beremoved, True, True)
  File "/usr/lib/python3.6/site-packages/pisi/operations/remove.py", line 87, in remove
    with open**(os.path**.join(ctx.config.info_dir(), ctx.const.installed_extra), "w") as ie_file:

```